### PR TITLE
Added a new GET handler to force downloading dataset.

### DIFF
--- a/app.py
+++ b/app.py
@@ -298,6 +298,19 @@ class EmailSendHandler(BaseHandler):
             self.mail.sendmail(msg['from'], [msg['to']], msg.as_string())
 
 
+class DataDownloadHandler(BaseHandler):
+    """Download a file"""
+    
+    def get(self, filename):
+        """Download the data file"""
+        with open('static/datasets/' + filename) as f:
+            self.set_header('Content-Type', 'text/plain')
+            self.set_header('Content-Disposition', 
+                            'attachment; filename=' + filename + '')
+            self.write(f.read())
+        
+
+
 class Application(tornado.web.Application):
     """Web app"""
     HOSTNAME = 'tenuto.bi.a.u-tokyo.ac.jp/tapp'
@@ -308,7 +321,8 @@ class Application(tornado.web.Application):
                     (r'/tapp/predict', QueryHandler),
                     (r'/tapp/predict/([\w\-]+)', PredictHandler),
                     (r'/tapp/result/([\w\-]+)', ResultPageHandler),
-                    (r'/tapp/mail/([\w\-]+)', EmailSendHandler)]
+                    (r'/tapp/mail/([\w\-]+)', EmailSendHandler),
+                    (r'/tapp/data/(\w+\.fasta)', DataDownloadHandler)]
 
         # Postgresql, utils, mails
         self.db = momoko.Pool(dsn = 'dbname=tapp user=tapp password=tapp'

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,10 +40,10 @@
 <p>The predicted result will be shown in a new page.</p>
 <p>The data sets used for training the model can be downloaded: </p>
 <div class="row">
-    <a href="{{ static_url('datasets/ta.fasta') }}" target="_blank" type="text/plain" download="ta.fasta" class="waves-effect waves-light btn">TA set</a>
-    <a href="{{ static_url('datasets/sp.fasta') }}" target="_blank" type="text/plain" download="sp.fasta" class="waves-effect waves-light btn">SP set</a>
-    <a href="{{ static_url('datasets/mp.fasta') }}" target="_blank" type="text/plain" download="mp.fasta" class="waves-effect waves-light btn">MP set</a>
-    <a href="{{ static_url('datasets/no.fasta') }}" target="_blank" type="text/plain" download="no.fasta" class="waves-effect waves-light btn">NO set</a>
+    <a href="/tapp/data/ta.fasta" target="_blank" type="text/plain" download="ta.fasta" class="waves-effect waves-light btn">TA set</a>
+    <a href="/tapp/data/sp.fasta" target="_blank" type="text/plain" download="sp.fasta" class="waves-effect waves-light btn">SP set</a>
+    <a href="/tapp/data/mp.fasta" target="_blank" type="text/plain" download="mp.fasta" class="waves-effect waves-light btn">MP set</a>
+    <a href="/tapp/data/no.fasta" target="_blank" type="text/plain" download="no.fasta" class="waves-effect waves-light btn">NO set</a>
 </div>
 
 {% end %}


### PR DESCRIPTION
# Problem
- In some browsers, users cannot download file correctly
  - Especially Internet Explorer shows the content with newlines trimmed instead of starting download.
# Solution
- Make another entry point to download a plain text file with `Content-Disposition` header. This header forces browsers to download the content as an attached file.
